### PR TITLE
1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+/classes
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ def createProject(
                    file: Option[String] = None,
                    settings: Seq[SettingsDefinition] = Seq(),
                  ): Project =
- Project(id = id, base = sbt.file(file match {
+  Project(id = id, base = sbt.file(file match {
     case Some(value) => value
     case None => id
   }))

--- a/cache/README.md
+++ b/cache/README.md
@@ -5,9 +5,22 @@ A collection of caches for... caching. Allows you to cache in whatever way possi
 ### Usage
 
 ```java
-Cache<String, String> cache = new HashingMemoryCache<>();
+// Single value cache
+Cache<String, String> cache = new MapMemoryCache<>(HashMap::new);
 cache.store("Hello", "World");
 System.out.println(cache.get("Hello")); // prints World
+
+// Multi value cache
+Cache<String, List<String>> cache = new MultiValueCacheDelegate(
+  new MapMemoryCache(HashMap::new),
+  ArrayList::new    
+);
+
+// Or if you want things like store(K key, V... values)
+MutliValueCache<String, String, List<String>> cache = new MultiValueCacheDelegate(
+                                                        new MapMemoryCache(HashMap::new),
+                                                        ArrayList::new    
+                                                      );
 ```
 
 ### Downloading

--- a/cache/src/main/java/it/xaan/random/cache/Cache.java
+++ b/cache/src/main/java/it/xaan/random/cache/Cache.java
@@ -19,6 +19,7 @@ package it.xaan.random.cache;
 
 import it.xaan.random.core.Pair;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -243,8 +244,8 @@ public interface Cache<K, V> {
    *
    * @return A set of all values that are in this cache.
    */
-  default Set<V> values() {
-    Set<V> values = new HashSet<>();
+  default Collection<V> values() {
+    List<V> values = new ArrayList<>();
     entries().forEach(pair -> values.add(pair.getSecond()));
     return values;
   }

--- a/cache/src/main/java/it/xaan/random/cache/MultiValueCache.java
+++ b/cache/src/main/java/it/xaan/random/cache/MultiValueCache.java
@@ -71,7 +71,10 @@ public interface MultiValueCache<K, V, C extends Collection<V>> extends Cache<K,
     C stored = supplier().get();
     stored.addAll(old);
     for (V value : values) {
-      stored.add(value);
+      // Null values not allowed
+      if (value != null) {
+        stored.add(value);
+      }
     }
     store(key, stored);
     return Optional.of(old);

--- a/cache/src/main/java/it/xaan/random/cache/MultiValueCache.java
+++ b/cache/src/main/java/it/xaan/random/cache/MultiValueCache.java
@@ -18,8 +18,9 @@
 package it.xaan.random.cache;
 
 import it.xaan.random.core.Pair;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -86,14 +87,14 @@ public interface MultiValueCache<K, V, C extends Collection<V>> extends Cache<K,
    * @return A {@link Set} of all entries flattened.
    */
   @SuppressWarnings("ConstantConditions")
-  default Set<Pair<K, V>> flatEntries() {
-    Set<Pair<K, V>> set = new HashSet<>();
+  default Collection<Pair<K, V>> flatEntries() {
+    List<Pair<K, V>> flattened = new ArrayList<>();
     for (Pair<K, C> entry : entries()) {
       for (V value : entry.getSecond()) {
-        set.add(Pair.from(entry.getFirst(), value));
+        flattened.add(Pair.from(entry.getFirst(), value));
       }
     }
-    return set;
+    return flattened;
   }
 
 

--- a/cache/src/main/java/it/xaan/random/cache/impl/MapMemoryCache.java
+++ b/cache/src/main/java/it/xaan/random/cache/impl/MapMemoryCache.java
@@ -59,6 +59,11 @@ public class MapMemoryCache<K, V> implements Cache<K, V> {
 
   @Override
   public Optional<V> store(K key, V value) {
+    // Certain maps allow null keys, value should be nevernull anyway
+    // but we have to assume people will pass it.
+    if (value == null) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(underlying.put(key, value));
   }
 

--- a/cache/src/test/java/it/xaan/random/cache/CacheTest.java
+++ b/cache/src/test/java/it/xaan/random/cache/CacheTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
@@ -179,8 +180,15 @@ public class CacheTest {
   @Test
   public void testValues() {
     final Cache<String, String> test = create();
-    final Set<String> values = new HashSet<>(Arrays.asList("value", "world"));
-    Assert.assertEquals(values, test.values());
+    final List<String> control = Arrays.stream(new String[]{"value", "world"})
+        .sorted()
+        .collect(Collectors.toList());
+
+    final List<String> values = test.values().stream()
+        .sorted()
+        .collect(Collectors.toList());
+
+    Assert.assertEquals(control, values);
   }
 
 }

--- a/cache/src/test/java/it/xaan/random/cache/MultiValueCacheTest.java
+++ b/cache/src/test/java/it/xaan/random/cache/MultiValueCacheTest.java
@@ -111,7 +111,7 @@ public final class MultiValueCacheTest {
   @Test
   public void testFlatEntries() {
     final MultiValueCache<String, String, List<String>> test = create(false);
-    Set<Pair<String, String>> flattened = new HashSet<>(
+    List<Pair<String, String>> flattened = new ArrayList<>(
         Arrays.asList(Pair.from("two", "1"), Pair.from("two", "2")));
     test.store("two", "1", "2");
     Assert.assertEquals(flattened, test.flatEntries());

--- a/result/src/main/java/it/xaan/random/result/Result.java
+++ b/result/src/main/java/it/xaan/random/result/Result.java
@@ -19,6 +19,7 @@ package it.xaan.random.result;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -294,6 +295,37 @@ public final class Result<T> {
    */
   public T get() {
     return orElseThrow(() -> new NoSuchElementException("Get call on non-successful Result."));
+  }
+
+  /**
+   * Retrieves the current error from this {@link Result} if it's in an Error state, otherwise
+   * errors.
+   *
+   * @return The non-null error.
+   * @throws NoSuchElementException if {@link #isError()} return false;
+   * @since 1.1.0
+   */
+  public Object getError() {
+    if (!isError()) {
+      throw new NoSuchElementException("Get error call on non-error Result");
+    }
+    return this.error;
+  }
+
+  /**
+   * Retrieves the current error from this {@link Result} if it's in an Error state if
+   * the error is of the passed class, otherwise errors.
+   *
+   * @param clazz The class to check against.
+   * @return An {@link Optional} containing the error if it exists and is of the passed class,
+   * otherwise an empty Optional.
+   * @throws NoSuchElementException if {@link #isError(Class)} return false;
+   * @since 1.1.0
+   */
+  public <U> Optional<U> getError(Class<? extends U> clazz) {
+    return Optional.of(getError())
+        .filter(obj -> isError(clazz))
+        .map(clazz::cast);
   }
 
   /**

--- a/result/src/test/java/it/xaan/random/result/ResultTest.java
+++ b/result/src/test/java/it/xaan/random/result/ResultTest.java
@@ -176,7 +176,6 @@ public class ResultTest {
 
   @Test
   public void testOrElseThrow() {
-    final String other = "Hello world";
     // Shouldn't be else for success
     Assert.assertEquals("Successful state.",
         success.orElseThrow(() -> new IllegalStateException("Shouldn't be here.")));
@@ -186,5 +185,18 @@ public class ResultTest {
         () -> empty.orElseThrow(() -> new NoSuchElementException("No such element.")));
     Assert.assertThrows(NoSuchElementException.class,
         () -> error.orElseThrow(() -> new NoSuchElementException("No such element.")));
+  }
+
+  @Test
+  public void testGetError() {
+    Assert.assertThrows(NoSuchElementException.class, success::getError);
+    Assert.assertSame(IllegalStateException.class, error.getError().getClass());
+  }
+
+  @Test
+  public void testGetErrorClass() {
+    Assert.assertThrows(NoSuchElementException.class, () -> success.getError(Object.class));
+    Assert.assertTrue(error.getError(IllegalStateException.class).isPresent());
+    Assert.assertFalse(error.getError(ResultTest.class).isPresent());
   }
 }


### PR DESCRIPTION
- Fix cache module README
  - HashingMemoryModule is useless
- Cache values aren't guaranteed to be unique, keys are. 
  - Subclasses may choose to make values unique, return type is `Collection` so this is still possible.
- Fixed a bug where null values were allowed in `MapMemoryCache` and `MultiValueCacheDelegate` due to maps like `HashMap` allowing null values, as shown by a call to `HashMap#entrySet`.
- You can now get the error from a `Result`. This works similarly to `get()`, but for errors.
